### PR TITLE
feat(catalog-ui): add language switcher to header profile menu

### DIFF
--- a/apps/catalog-ui/docs/components/profile/HeaderProfile.md
+++ b/apps/catalog-ui/docs/components/profile/HeaderProfile.md
@@ -1,7 +1,7 @@
 # **HeaderProfile**
 
 The **HeaderProfile** component displays the authenticated user's profile information in the application header.
-It renders a button showing the user's name and, on click, opens a dropdown menu with the full name and email address retrieved from the LinID user store.
+It renders a button showing the user's name and, on click, opens a dropdown menu with the full name and email address retrieved from the LinID user store, together with a language switcher that lets the user change the application language.
 
 ---
 
@@ -9,7 +9,9 @@ It renders a button showing the user's name and, on click, opens a dropdown menu
 
 - Displays the authenticated user's identity in the header
 - Provides quick access to profile information (name and email) via a dropdown menu
+- Allows the user to switch the application language via a dropdown selector
 - Integrates with the LinID user store to reactively reflect the current user state
+- Integrates with the UI store and the corelib i18n helpers to read and update the active locale
 - Integrates with the LinID design system for consistent styling
 - Extensible via `LinidZoneRenderer`: plugins can inject additional menu items into the profile dropdown
 
@@ -32,7 +34,38 @@ export interface HeaderProfileProps extends CommonComponentProps {}
 
 ## **Events**
 
-This component emits no events.
+This component emits no events. Language selection updates the shared i18n instance directly rather than emitting an event to the parent.
+
+---
+
+## **Language Switcher**
+
+The profile menu includes a language selector. Its data comes from several distinct sources, all provided by the **host** application; the component itself contains no hard-coded language list, name or flag.
+
+### How it works
+
+1. **Available languages** — read from the UI store (`useLinidUiStore().i18n.languages`), which reflects the locales declared in the host configuration (`config.json` → `i18n.languages`). The dropdown list is built by iterating over this array, so adding a language to the host configuration automatically adds it to the switcher.
+2. **Active language** — read from the UI store (`useLinidUiStore().i18n.locale`) and kept in sync with it: if the locale changes outside the component (e.g. the user preference is resolved after mount), the selector updates automatically. On selection, the component calls the corelib `changeLocale` helper, which updates the whole UI reactively.
+3. **Language display names (endonyms)** — resolved through the `application` i18n scope: `t('languages.' + locale)`. Values are each language written in its own language (e.g. "Français", "English (US)"), so they must be **identical across all locale files** (see the i18n documentation).
+4. **Flags** — served by the host as static SVG files at `/icons/{locale}.svg` (e.g. `/icons/fr-FR.svg`). The component references them by an absolute URL built from the locale code; it does **not** import or bundle them. This keeps the flags out of the Module Federation bundle but couples the component to a host that serves these files.
+
+### Host requirements
+
+To use the language switcher, the host **must** provide, for every supported locale:
+
+- locale messages loaded for each language listed in `config.json` → `i18n.languages`
+- the translation key `application.language.title`
+- the translation key `application.languages.{locale}`
+- a flag SVG served at `/icons/{locale}.svg`
+
+If any of these is missing for a given locale, that language will render with a broken flag image or an untranslated key, and no error will be raised.
+
+### Behaviour notes
+
+- The currently active language stays visible in the list but is **disabled** (not selectable), per specification.
+- Selecting a language closes the entire profile menu. This is both the expected behaviour for a selector and a deliberate fix: the select re-measures its width on the next open, which avoids a layout overlap that occurred when the label changed while the menu stayed open.
+- Selecting a language calls the corelib `changeLocale` helper, which applies the locale to vue-i18n, reflects it in the UI store, and persists the choice (localStorage and, when it differs, the server-side user preference).
+- If `changeLocale` fails, the error is logged and the selection reverts to the locale from the UI store.
 
 ---
 
@@ -43,6 +76,11 @@ The component uses the LinID design system through `useUiDesign()`. The local na
 - **Button**: `{uiNamespace}.header-profile` → applies to `q-btn`
 - **Avatar section**: `{uiNamespace}.header-profile` → applies to `q-item-section` (icon side)
 - **Email label**: `{uiNamespace}.header-profile` → applies to `q-item-label` (caption)
+- **Language selector**: `{uiNamespace}.header-profile` → applies to `q-select`
+- **Language option items**: `{uiNamespace}.header-profile` → applies to `q-item` (merged with Quasar's own option props)
+- **Flag images**: `{uiNamespace}.header-profile` → applies to `q-img`
+
+> **Note:** The flags are static SVGs served by the host at `/icons/{locale}.svg`; only their `q-img` props (size, ratio, …) are configurable through the design system.
 
 Here is a sample JSON configuration for the design system:
 
@@ -60,6 +98,16 @@ Here is a sample JSON configuration for the design system:
       },
       "q-item-label": {
         "caption": true
+      },
+      "q-select": {
+        "dense": true,
+        "borderless": true
+      },
+      "q-item": {
+        "dense": true
+      },
+      "q-img": {
+        "width": "24px"
       }
     }
   }
@@ -70,9 +118,9 @@ Here is a sample JSON configuration for the design system:
 
 ## **Advantages**
 
-- **Reactive:** Automatically reflects user state changes via Pinia store
+- **Reactive:** Automatically reflects user state changes via Pinia store and the shared i18n instance
 - **Consistent:** Integrates with the LinID design system for uniform header styling
-- **Minimal:** No events, no complex state — read-only display component
+- **Configuration-driven:** The language list is derived from the host i18n configuration, not hard-coded
 - **Type-safe:** Full TypeScript support via `CommonComponentProps`
 - **Test-friendly:** Includes `data-cy` attributes for E2E testing
 - **Federation-ready:** Exposed as a Module Federation remote for consumption by host applications
@@ -132,6 +180,9 @@ The component includes `data-cy` attributes for Cypress testing:
 - Profile info item: `data-cy="header_profile_info"`
 - User full name: `data-cy="header_profile_name"`
 - User email: `data-cy="header_profile_email"`
+- Language selector row: `data-cy="header_profile_language"`
+- Language selector: `data-cy="header_profile_language_select"`
+- Language option (per locale): `data-cy="header_profile_language_option_[LOCALE]"`
 
 Example test:
 
@@ -140,6 +191,8 @@ cy.get('[data-cy="header_profile_button"]').click();
 cy.get('[data-cy="header_profile_menu"]').should('be.visible');
 cy.get('[data-cy="header_profile_name"]').should('contain.text', 'John Doe');
 cy.get('[data-cy="header_profile_email"]').should('contain.text', 'john.doe@example.com');
+cy.get('[data-cy="header_profile_language_select"]').click();
+cy.get('[data-cy="header_profile_language_option_en-US"]').click();
 ```
 
 ---
@@ -150,6 +203,7 @@ cy.get('[data-cy="header_profile_email"]').should('contain.text', 'john.doe@exam
 - The component has no fallback display when the user is not authenticated; the parent layout is responsible for rendering it only when a user session exists
 - The template is excluded from v8 coverage (`<!-- v8 ignore start/stop -->`) as it contains only presentation logic
 - **UI namespacing:** The local namespace `{uiNamespace}.header-profile` is derived from the prop, allowing each host application to style the component independently
+- **Host coupling:** The language switcher expects the host to serve flag assets at `/icons/{locale}.svg` and to provide the `application.language.title` and `application.languages.{locale}` translation keys. Reusing this component in another host requires these to be present.
 
 ---
 
@@ -160,11 +214,13 @@ The component follows a simple reactive read pattern:
 1. **Props in:** Receives `uiNamespace` to build its design system namespace
 2. **Store read:** Reads `fullName` and `email` from `useLinidUserStore()` as computed properties
 3. **UI props:** Resolves Quasar component props via `useUiDesign()` for `q-btn`, `q-item-section`, and `q-item-label`
-4. **Render:** Displays a `q-btn` with the user's name; on click, a `q-menu` shows the full profile info
-5. **Extension point:** A `LinidZoneRenderer` with zone `{uiNamespace}.header-profile.menu-items` allows plugins to inject additional menu items (e.g. logout, settings)
+4. **i18n read:** Reads the active locale and the list of available locales from the UI store (`useLinidUiStore().i18n`); resolves the switcher title and the language names via the `application` scope
+5. **Render:** Displays a `q-btn` with the user's name; on click, a `q-menu` shows the full profile info
+6. **Language switch:** On selecting a language, calls the corelib `changeLocale` helper — which applies the locale to vue-i18n (updating the whole UI reactively), reflects it in the store, and persists it — then closes the profile menu. The currently active language is shown but disabled in the list.
+7. **Extension point:** A `LinidZoneRenderer` with zone `{uiNamespace}.header-profile.menu-items` allows plugins to inject additional menu items (e.g. logout, settings)
 
 This architecture ensures:
 
-- **Separation of concerns:** User data management is handled by the store, not the component
-- **Reusability:** The component can be dropped into any layout that provides the correct `uiNamespace`
+- **Separation of concerns:** User data is handled by the user store, locale state by the UI store and the corelib i18n helpers, not the component
+- **Reusability:** The component can be dropped into any layout that provides the correct `uiNamespace` and the required host resources
 - **Reactivity:** Any update to the user store is automatically reflected without additional wiring

--- a/apps/catalog-ui/docs/design.md
+++ b/apps/catalog-ui/docs/design.md
@@ -64,7 +64,7 @@ The main application layout with header, toolbar, and navigation.
 
 ### HeaderProfile
 
-User profile button displayed in the application header. This component is a child of BaseLayout.
+User profile button displayed in the application header, including a language switcher. This component is a child of BaseLayout.
 
 **Namespace:** `{uiNamespace}.header-profile`
 
@@ -75,12 +75,17 @@ User profile button displayed in the application header. This component is a chi
       "header-profile": {
         "q-btn": { "flat": true, "round": false, "color": "white", "noCaps": true },
         "q-item-section": { "avatar": true },
-        "q-item-label": { "caption": true }
+        "q-item-label": { "caption": true },
+        "q-img": {},
+        "q-select": {},
+        "q-item": {}
       }
     }
   }
 }
 ```
+
+> **Note:** Flags are static SVG files served by the host at `/icons/{locale}.svg`; language names come from i18n (`application.languages.{locale}`).
 
 ---
 
@@ -1243,7 +1248,10 @@ A full example showing all CatalogUI components configured together:
       "header-profile": {
         "q-btn": { "flat": true, "color": "white", "noCaps": true },
         "q-item-section": { "avatar": true },
-        "q-item-label": { "caption": true }
+        "q-item-label": { "caption": true },
+        "q-img": {},
+        "q-select": {},
+        "q-item": {}
       },
       "navigation-menu": {
         "q-tabs": { "dense": false, "align": "left", "noCaps": true },

--- a/apps/catalog-ui/docs/i18n.md
+++ b/apps/catalog-ui/docs/i18n.md
@@ -32,7 +32,30 @@ This document lists the translation keys used by the catalog-ui shared component
 
 **File:** apps/catalog-ui/src/components/profile/HeaderProfile.vue
 
-This component has no translation keys. User information (name and email) is read directly from the LinID user store.
+User information (name and email) is read directly from the LinID user store and requires no translation keys. The language switcher uses the `application` scope for both the selector title and the language display names (endonyms) shown in the selector and in the list.
+
+| Key                              | Description                                              | Usage                        | Parameters         |
+| -------------------------------- | -------------------------------------------------------- | ---------------------------- | ------------------ |
+| `application.language.title`     | Label of the language selector row                       | Language item title          | -                  |
+| `application.languages.[LOCALE]` | Display name of a language in its own language (endonym) | Selector label and list item | `[LOCALE]` dynamic |
+
+> **Note:** `application.languages.[LOCALE]` values are endonyms (each language written in itself), so they must be **identical across all locale files** — e.g. `application.languages.fr-FR` reads "Français" in both `fr-FR` and `en-US`. The `[LOCALE]` segment matches the locale codes declared in the application configuration (`config.json` → `i18n.languages`). Every locale listed there must have a matching `application.languages.[LOCALE]` entry, otherwise the raw key is displayed.
+
+**Example:**
+
+```json
+{
+  "application": {
+    "language": {
+      "title": "Language"
+    },
+    "languages": {
+      "fr-FR": "Français",
+      "en-US": "English (US)"
+    }
+  }
+}
+```
 
 ---
 
@@ -915,6 +938,13 @@ export default {
   application: {
     title: 'LinID Identity Manager',
     version: 'v1.0.0',
+    language: {
+      title: 'Language',
+    },
+    languages: {
+      'fr-FR': 'Français',
+      'en-US': 'English (US)',
+    },
   },
   '[INSTANCE_ID]': {
     ButtonsCard: {

--- a/apps/catalog-ui/src/components/profile/HeaderProfile.vue
+++ b/apps/catalog-ui/src/components/profile/HeaderProfile.vue
@@ -32,7 +32,10 @@
     :label="name"
     data-cy="header_profile_button"
   >
-    <q-menu data-cy="header_profile_menu">
+    <q-menu
+      ref="profileMenu"
+      data-cy="header_profile_menu"
+    >
       <q-list>
         <q-item data-cy="header_profile_info">
           <q-item-section v-bind="uiProps.itemSection">
@@ -50,6 +53,47 @@
           </q-item-section>
         </q-item>
         <q-separator />
+        <q-item data-cy="header_profile_language">
+          <q-item-section>
+            <q-item-label>{{ t('language.title') }}</q-item-label>
+          </q-item-section>
+          <q-item-section class="col-auto">
+            <q-select
+              v-bind="uiProps.select"
+              v-model="selectedLanguage"
+              :options="availableLocales"
+              :option-disable="(code) => code === selectedLanguage"
+              data-cy="header_profile_language_select"
+            >
+              <template #selected>
+                <div class="row items-center no-wrap">
+                  <q-img
+                    v-bind="uiProps.flag"
+                    :src="`/icons/${selectedLanguage}.svg`"
+                    class="q-mr-sm"
+                  />
+                  <span>{{ t(`languages.${selectedLanguage}`) }}</span>
+                </div>
+              </template>
+              <template #option="scope">
+                <q-item
+                  v-bind="{ ...uiProps.item, ...scope.itemProps }"
+                  :data-cy="`header_profile_language_option_${scope.opt}`"
+                >
+                  <q-item-section avatar>
+                    <q-img
+                      v-bind="uiProps.flag"
+                      :src="`/icons/${scope.opt}.svg`"
+                    />
+                  </q-item-section>
+                  <q-item-section>
+                    {{ t(`languages.${scope.opt}`) }}
+                  </q-item-section>
+                </q-item>
+              </template>
+            </q-select>
+          </q-item-section>
+        </q-item>
         <LinidZoneRenderer :zone="`${localUiNamespace}.menu-items`" />
       </q-list>
     </q-menu>
@@ -60,28 +104,73 @@
 <script setup lang="ts">
 import type {
   LinidQBtnProps,
+  LinidQImgProps,
   LinidQItemLabelProps,
+  LinidQItemProps,
+  LinidQSelectProps,
   LinidQItemSectionProps,
 } from '@linagora/linid-im-front-corelib';
 import {
   LinidZoneRenderer,
   useLinidUserStore,
+  useLinidUiStore,
   useUiDesign,
+  useScopedI18n,
+  changeLocale,
 } from '@linagora/linid-im-front-corelib';
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import type { CommonComponentProps } from '../../types/common';
+import type { QMenu } from 'quasar';
 
 const props = defineProps<CommonComponentProps>();
 
 const { ui } = useUiDesign();
+const { t } = useScopedI18n('application');
 const userStore = useLinidUserStore();
+const uiStore = useLinidUiStore();
 const name = computed(() => userStore.user.fullName);
 const email = computed(() => userStore.user.email);
+const availableLocales = computed(() => uiStore.i18n.languages);
 
 const localUiNamespace = `${props.uiNamespace}.header-profile`;
+
 const uiProps = {
   btn: ui<LinidQBtnProps>(localUiNamespace, 'q-btn'),
   itemSection: ui<LinidQItemSectionProps>(localUiNamespace, 'q-item-section'),
   itemLabel: ui<LinidQItemLabelProps>(localUiNamespace, 'q-item-label'),
+  flag: ui<LinidQImgProps>(localUiNamespace, 'q-img'),
+  select: ui<LinidQSelectProps>(localUiNamespace, 'q-select'),
+  item: ui<LinidQItemProps>(localUiNamespace, 'q-item'),
 };
+
+const selectedLanguage = ref(uiStore.i18n.locale);
+const profileMenu = ref<QMenu>();
+
+/**
+ * Keeps the selector in sync when the locale changes outside the component,
+ * such as when the user preference is resolved after mount.
+ */
+watch(
+  () => uiStore.i18n.locale,
+  (locale) => {
+    selectedLanguage.value = locale;
+  }
+);
+
+/**
+ * Applies the selected locale and closes the profile menu when the user picks a language.
+ * Skips changes coming from the store sync above, and reverts the selection if the locale
+ * could not be applied.
+ */
+watch(selectedLanguage, (code) => {
+  if (code === uiStore.i18n.locale) {
+    return;
+  }
+
+  profileMenu.value?.hide();
+  changeLocale(code).catch((e) => {
+    console.error('changeLocale failed', e);
+    selectedLanguage.value = uiStore.i18n.locale;
+  });
+});
 </script>

--- a/apps/catalog-ui/tests/unit/components/profile/HeaderProfile.spec.js
+++ b/apps/catalog-ui/tests/unit/components/profile/HeaderProfile.spec.js
@@ -24,9 +24,10 @@
  * LinID Identity Manager software.
  */
 
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, flushPromises } from '@vue/test-utils';
 import { reactive } from 'vue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { changeLocale } from '@linagora/linid-im-front-corelib';
 import HeaderProfile from '../../../../src/components/profile/HeaderProfile.vue';
 
 const mockUserStore = reactive({
@@ -40,10 +41,16 @@ const mockUserStore = reactive({
 });
 
 const mockUi = vi.fn(() => ({}));
+const mockUiStore = reactive({
+  i18n: { locale: 'fr-FR', languages: ['fr-FR', 'en-US'] },
+});
 
 vi.mock('@linagora/linid-im-front-corelib', () => ({
   useLinidUserStore: () => mockUserStore,
+  useLinidUiStore: () => mockUiStore,
   useUiDesign: () => ({ ui: mockUi }),
+  useScopedI18n: () => ({ t: (key) => key }),
+  changeLocale: vi.fn(() => Promise.resolve()),
   LinidZoneRenderer: { template: '<div />' },
 }));
 
@@ -64,6 +71,8 @@ describe('Test component: HeaderProfile', () => {
       roles: [],
     };
     mockUserStore.isAuthenticated = true;
+
+    mockUiStore.i18n = { locale: 'fr-FR', languages: ['fr-FR', 'en-US'] };
 
     wrapper = shallowMount(HeaderProfile, {
       props: defaultProps,
@@ -107,6 +116,90 @@ describe('Test component: HeaderProfile', () => {
 
     it('should call ui with header-profile.email namespace for q-item-label', () => {
       expect(mockUi).toHaveBeenCalledWith(localUiNamespace, 'q-item-label');
+    });
+  });
+
+  describe('Test computed: availableLocales', () => {
+    it('should return the languages from the ui store', () => {
+      expect(wrapper.vm.availableLocales).toEqual(['fr-FR', 'en-US']);
+    });
+  });
+
+  describe('Test watch: selectedLanguage', () => {
+    it('should call changeLocale when the selected language changes', async () => {
+      wrapper.vm.selectedLanguage = 'en-US';
+      await wrapper.vm.$nextTick();
+
+      expect(vi.mocked(changeLocale)).toHaveBeenCalledWith('en-US');
+    });
+
+    it('should hide the profile menu when the selected language changes', async () => {
+      const hide = vi.fn();
+      wrapper.vm.profileMenu = { hide };
+
+      wrapper.vm.selectedLanguage = 'en-US';
+      await wrapper.vm.$nextTick();
+
+      expect(hide).toHaveBeenCalled();
+    });
+
+    it('should log an error when changeLocale fails', async () => {
+      const error = new Error('boom');
+      vi.mocked(changeLocale).mockRejectedValueOnce(error);
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(vi.fn());
+
+      wrapper.vm.selectedLanguage = 'en-US';
+      await wrapper.vm.$nextTick();
+      await flushPromises();
+
+      expect(consoleError).toHaveBeenCalledWith('changeLocale failed', error);
+
+      consoleError.mockRestore();
+    });
+
+    it('should revert the selection to the store locale when changeLocale fails', async () => {
+      vi.mocked(changeLocale).mockRejectedValueOnce(new Error('boom'));
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(vi.fn());
+
+      wrapper.vm.selectedLanguage = 'en-US';
+      await wrapper.vm.$nextTick();
+      await flushPromises();
+
+      expect(wrapper.vm.selectedLanguage).toBe('fr-FR');
+
+      consoleError.mockRestore();
+    });
+
+    it('should not call changeLocale when the selection is synced from the store', async () => {
+      mockUiStore.i18n.locale = 'en-US';
+      await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      expect(vi.mocked(changeLocale)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Test watch: uiStore.i18n.locale', () => {
+    it('should sync selectedLanguage when the store locale changes', async () => {
+      mockUiStore.i18n.locale = 'en-US';
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.selectedLanguage).toBe('en-US');
+    });
+
+    it('should not hide the profile menu when the store locale changes', async () => {
+      const hide = vi.fn();
+      wrapper.vm.profileMenu = { hide };
+
+      mockUiStore.i18n.locale = 'en-US';
+      await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      expect(hide).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Description
Adds the language switcher component to the header profile menu (ticket [#199](https://github.com/linagora/linid-identity-manager/pull/199)):

* `HeaderProfile` language switcher built with `q-select` (flag + endonym per language)
* reads available languages and active locale from the corelib UI store
* applies and persists the selected language via the corelib `changeLocale` helper
* component documentation updated (`HeaderProfile.md`, `design.md`, `i18n.md`)

## Linked PR
Related to https://github.com/linagora/linid-im-front-corelib/pull/120 (merged)

## Out of scope
* Unit / e2e tests — to be added in a follow-up

## Ticket
[#199](https://github.com/linagora/linid-identity-manager/pull/199)